### PR TITLE
Fix for issue #94: Escape \u if following 4 characters is not hex digits

### DIFF
--- a/src/serializer.c
+++ b/src/serializer.c
@@ -51,7 +51,8 @@ static void   jx_EncodeJsonStream (PSTREAM p , PUCHAR in)
 			}
 		}
 		else if  (c  == pJw->backSlash) {
-			if (in[1] != 'u'   // Dont double escape unicode escape sequence
+			// Dont double escape unicode escape sequence
+			if (strlen(in) < 6 || in[1] != 'u'   
 				|| !isxdigit(in[2]) || !isxdigit(in[3])
 				|| !isxdigit(in[4]) || !isxdigit(in[5])) {  
 				stream_putc(p,pJw->backSlash);

--- a/src/serializer.c
+++ b/src/serializer.c
@@ -51,7 +51,9 @@ static void   jx_EncodeJsonStream (PSTREAM p , PUCHAR in)
 			}
 		}
 		else if  (c  == pJw->backSlash) {
-			if (in[1] != 'u') {  // Dont double escape unicode escape sequence
+			if (in[1] != 'u'   // Dont double escape unicode escape sequence
+				|| !isxdigit(in[2]) || !isxdigit(in[3])
+				|| !isxdigit(in[4]) || !isxdigit(in[5])) {  
 				stream_putc(p,pJw->backSlash);
 			}
 		}


### PR DESCRIPTION
Suggestion for fixing issue #94 