### PR TITLE
New optional parameter for serializing matching values as null

### DIFF
--- a/headers/JSONPARSER.rpgle
+++ b/headers/JSONPARSER.rpgle
@@ -523,12 +523,14 @@ End-PR;
 // @param Node
 // @param Node path expression
 // @param New string value
+// @param Value to be replaced with null
 // @return Changed node
 ///
 Dcl-PR json_setStr pointer extproc(*CWIDEN : 'jx_SetStrByName');
   node pointer value;
   nodePath pointer value options(*string);
   value pointer value options(*string);
+  nullValue pointer value options(*string : *nopass);
 End-PR;
 
 ///

--- a/headers/JSONXML.rpgle
+++ b/headers/JSONXML.rpgle
@@ -523,12 +523,14 @@ End-PR;
 // @param Node
 // @param Node path expression
 // @param New string value
+// @param Value to be replaced with null
 // @return Changed node
 ///
 Dcl-PR jx_setStr pointer extproc(*CWIDEN : 'jx_SetStrByName');
   node pointer value;
   nodePath pointer value options(*string);
   value pointer value options(*string);
+  nullValue pointer value options(*string : *nopass);
 End-PR;
 
 ///

--- a/headers/NOXDB.rpgle
+++ b/headers/NOXDB.rpgle
@@ -523,12 +523,14 @@ End-PR;
 // @param Node
 // @param Node path expression
 // @param New string value
+// @param Value to be replaced with null
 // @return Changed node
 ///
 Dcl-PR json_setStr pointer extproc(*CWIDEN : 'jx_SetStrByName');
   node pointer value;
   nodePath pointer value options(*string);
   value pointer value options(*string);
+  nullValue pointer value options(*string : *nopass);
 End-PR;
 
 ///
@@ -3294,6 +3296,7 @@ Dcl-PR xml_setStr pointer extproc(*CWIDEN : 'jx_SetStrByName');
   node pointer value;
   nodePath pointer value options(*string);
   value pointer value options(*string);
+  nullValue pointer value options(*string : *nopass);
 End-PR;
 
 ///

--- a/headers/XMLPARSER.rpgle
+++ b/headers/XMLPARSER.rpgle
@@ -523,12 +523,14 @@ End-PR;
 // @param Node
 // @param Node path expression
 // @param New string value
+// @param Value to be replaced with null
 // @return Changed node
 ///
 Dcl-PR xml_setStr pointer extproc(*CWIDEN : 'jx_SetStrByName');
   node pointer value;
   nodePath pointer value options(*string);
   value pointer value options(*string);
+  nullValue pointer value options(*string : *nopass);
 End-PR;
 
 ///

--- a/headers/jsonxml.h
+++ b/headers/jsonxml.h
@@ -509,7 +509,9 @@ PJXNODE  jx_LookupValue (PJXNODE pDest, PUCHAR expr , BOOL16 ignorecase);
 LONG     jx_getLength (PJXNODE pNode);
 ULONG     jx_NodeCheckSum (PJXNODE pNode);
 
-PJXNODE  jx_SetStrByName (PJXNODE pNode, PUCHAR Name, PUCHAR Value);
+PJXNODE  jx_SetStrByName (PJXNODE pNode, PUCHAR Name, PUCHAR Value, PUCHAR NullValue);
+#pragma descriptor ( void jx_SetStrByName      (void))
+
 PJXNODE  jx_SetBoolByName (PJXNODE pNode, PUCHAR Name, LGL Value);
 PJXNODE  jx_SetCharByName (PJXNODE pNode, PUCHAR Name, UCHAR Value);
 PJXNODE  jx_SetDecByName (PJXNODE pNode, PUCHAR Name, FIXEDDEC Value);

--- a/src/noxdb.c
+++ b/src/noxdb.c
@@ -3303,8 +3303,14 @@ PJXNODE  jx_SetCharByName (PJXNODE pNode, PUCHAR Name, UCHAR Value)
 /* -------------------------------------------------------------
    Set String by name
    ------------------------------------------------------------- */
-PJXNODE  jx_SetStrByName (PJXNODE pNode, PUCHAR Name, PUCHAR Value)
+PJXNODE  jx_SetStrByName (PJXNODE pNode, PUCHAR Name, PUCHAR Value, PUCHAR NullValue)
 {
+   PNPMPARMLISTADDRP pParms = _NPMPARMLISTADDR();
+   if (pParms->OpDescList->NbrOfParms >= 4) {
+      if (strcmp(Value, NullValue) == 0) {
+         return jx_SetNullByName(pNode, Name);
+      }
+   }
    return jx_SetValueByName(pNode , Name , Value , VALUE );
 }
 /* -------------------------------------------------------------
@@ -3677,11 +3683,11 @@ PJXNODE jx_GetMessageObject (PUCHAR msgId , PUCHAR msgDta)
    PJXNODE pMsg = jx_NewObject(NULL);
    jx_SetBoolByName (pMsg , "success" ,  OFF);
    if (pParms->OpDescList->NbrOfParms > 0)  {
-      jx_SetStrByName (pMsg , "msgId" ,  msgId);
-      jx_SetStrByName (pMsg , "msgDta",  msgDta);
+      jx_SetStrByName (pMsg , "msgId" ,  msgId, NULL);
+      jx_SetStrByName (pMsg , "msgDta",  msgDta, NULL);
       // TODO - convert the msgid / msgData to text
    } else  {
-      jx_SetStrByName (pMsg , "msg" ,  jxMessage);
+      jx_SetStrByName (pMsg , "msg" ,  jxMessage, NULL);
    }
    return pMsg;
 }

--- a/src/sqlio.c
+++ b/src/sqlio.c
@@ -2646,8 +2646,8 @@ PJXNODE static sqlErrorObject(PUCHAR sqlstmt)
 {
    PJXNODE pError = jx_NewObject(NULL);
    jx_SetBoolByName (pError , "success" ,  OFF);
-   jx_SetStrByName  (pError , "msg"     ,  jxMessage);
-   jx_SetStrByName  (pError , "stmt"    ,  sqlstmt);
+   jx_SetStrByName  (pError , "msg"     ,  jxMessage , NULL);
+   jx_SetStrByName  (pError , "stmt"    ,  sqlstmt   , NULL);
    messageList (pError);
 
    return pError;


### PR DESCRIPTION
When serializing json response-payloads we often want to return null instead of empty strings, zeros etc. when there is no value. We have made our own extension to NoxDB to achieve this without having to do a if-else block, but it would be nice to have this in NoxDB itself.

Example - instead of:
```
if (myStr = '');
  json_SetNull(json : 'someString');
else;
  json_SetStr(json : 'someString' : myStr);
endif;
```

we could do:
```
json_SetStr(json : 'someString' : myStr : '');  // any string matching '' would be serialized as null
```

The new fourth parameter is optional (*nopass), and without it the behaviour is as before. No breaking change.

@NielsLiisberg : Please let me know if this is something you would consider merging, and I will provide implementation for the others as well (SetInt, SetDate, etc).